### PR TITLE
Remove Fixnum deprecation for Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: ruby
+
+rvm:
+  - 2.2
+  - 2.3.3
+  - 2.4.1
+
+bundler_args: --without development
+
+sudo: false
+
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,6 @@ group :dev do
   gem 'msgpack'
 end
 
+group :test do
+  gem 'test-unit'
+end

--- a/lib/horcrux/entity.rb
+++ b/lib/horcrux/entity.rb
@@ -63,7 +63,7 @@ module Horcrux
 
           define_method "#{key_s}=" do |value|
             instance_variable_set ivar_key, case value
-              when Fixnum  then value > 0
+              when Integer then value > 0
               when /t|f/i  then value =~ /t/i ? true : false
               else !!value
             end


### PR DESCRIPTION
This removes the following warning if you're using horcrux in Ruby 2.4

```
vendor/gems/2.4.0/ruby/2.4.0/gems/horcrux-0.1.1/lib/horcrux/entity.rb:66: warning: constant ::Fixnum is deprecated
```

I've updated the use of `Fixnum` to use `Integer`, as a sanity check I added a travis.yml file to test against all supported versions of Ruby.

Here's the passing build https://travis-ci.org/tarebyte/horcrux/builds/265687050

I'm happy to remove the file if you don't want it as part of the gem 😄 